### PR TITLE
Add migration after upgrading decidim 0.16.0

### DIFF
--- a/db/migrate/20190214155425_remove_decidim_surveys_tables_after_migrate_to_decidim_forms.rb
+++ b/db/migrate/20190214155425_remove_decidim_surveys_tables_after_migrate_to_decidim_forms.rb
@@ -1,0 +1,15 @@
+class RemoveDecidimSurveysTablesAfterMigrateToDecidimForms < ActiveRecord::Migration[5.2]
+  def up
+    # Drop tables
+    drop_table :decidim_surveys_survey_answers
+    drop_table :decidim_surveys_survey_answer_choices
+    drop_table :decidim_surveys_survey_answer_options
+    drop_table :decidim_surveys_survey_questions
+
+    # Drop columns from surveys table
+    remove_column :decidim_surveys_surveys, :title
+    remove_column :decidim_surveys_surveys, :description
+    remove_column :decidim_surveys_surveys, :tos
+    remove_column :decidim_surveys_surveys, :published_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_102638) do
+ActiveRecord::Schema.define(version: 2019_02_14_155425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1170,54 +1170,8 @@ ActiveRecord::Schema.define(version: 2019_02_14_102638) do
     t.index ["topic_id"], name: "index_decidim_static_pages_on_topic_id"
   end
 
-  create_table "decidim_surveys_survey_answer_choices", force: :cascade do |t|
-    t.bigint "decidim_survey_answer_id"
-    t.bigint "decidim_survey_answer_option_id"
-    t.jsonb "body"
-    t.text "custom_body"
-    t.integer "position"
-    t.index ["decidim_survey_answer_id"], name: "index_decidim_surveys_answer_choices_answer_id"
-    t.index ["decidim_survey_answer_option_id"], name: "index_decidim_surveys_answer_choices_answer_option_id"
-  end
-
-  create_table "decidim_surveys_survey_answer_options", force: :cascade do |t|
-    t.bigint "decidim_survey_question_id"
-    t.jsonb "body"
-    t.boolean "free_text"
-    t.index ["decidim_survey_question_id"], name: "index_decidim_surveys_answer_options_question_id"
-  end
-
-  create_table "decidim_surveys_survey_answers", id: :serial, force: :cascade do |t|
-    t.integer "decidim_user_id"
-    t.integer "decidim_survey_id"
-    t.integer "decidim_survey_question_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text "body"
-    t.index ["decidim_survey_id"], name: "index_decidim_surveys_survey_answers_on_decidim_survey_id"
-    t.index ["decidim_survey_question_id"], name: "index_decidim_surveys_answers_question_id"
-    t.index ["decidim_user_id"], name: "index_decidim_surveys_survey_answers_on_decidim_user_id"
-  end
-
-  create_table "decidim_surveys_survey_questions", id: :serial, force: :cascade do |t|
-    t.jsonb "body"
-    t.integer "decidim_survey_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "position"
-    t.boolean "mandatory"
-    t.string "question_type"
-    t.integer "max_choices"
-    t.jsonb "description"
-    t.index ["decidim_survey_id"], name: "index_decidim_surveys_survey_questions_on_decidim_survey_id"
-  end
-
   create_table "decidim_surveys_surveys", id: :serial, force: :cascade do |t|
-    t.jsonb "title"
-    t.jsonb "description"
-    t.jsonb "tos"
     t.integer "decidim_component_id"
-    t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["decidim_component_id"], name: "index_decidim_surveys_surveys_on_decidim_component_id"


### PR DESCRIPTION
As the [Change Log](https://github.com/decidim/decidim/blob/0.16-stable/CHANGELOG.md) says:
>Once you are sure that the data is migrated, you can create a migration in your app to remove the old decidim_surveys tables