### PR TITLE
Fix CAS logout cross-host redirect (UnsafeRedirectError)

### DIFF
--- a/app/controllers/concerns/som_energia/devise/sessions_controller_override.rb
+++ b/app/controllers/concerns/som_energia/devise/sessions_controller_override.rb
@@ -14,6 +14,19 @@ module SomEnergia
           # Fallback to the referer or the default path
           request.referer || super
         end
+
+        private
+
+        def respond_to_on_destroy
+          respond_to do |format|
+            format.all { head :no_content }
+            format.any(*navigational_formats) do
+              redirect_to after_sign_out_path_for(resource_name),
+                          status: ::Devise.responder.redirect_status,
+                          allow_other_host: true
+            end
+          end
+        end
       end
     end
   end

--- a/spec/requests/cas_logout_spec.rb
+++ b/spec/requests/cas_logout_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "CAS logout" do # rubocop:disable RSpec/DescribeClass
+  include Devise::Test::IntegrationHelpers
+
+  let(:organization) { create(:organization) }
+  let!(:user) { create(:user, :confirmed, organization:) }
+  let(:cas_logout_url) { "https://cas.example.org/logout" }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with("CAS_LOGOUT_URL", nil).and_return(cas_logout_url)
+    host! organization.host
+    sign_in user
+  end
+
+  it "redirects to the CAS logout URL on a different host without raising" do
+    delete decidim.destroy_user_session_path
+
+    expect(response).to have_http_status(:redirect)
+    expect(response.location).to start_with("#{cas_logout_url}?service=")
+  end
+end


### PR DESCRIPTION
## Description

After upgrading to Decidim 0.31 / Rails 7, logging out crashed with `ActionController::Redirecting::UnsafeRedirectError` because Devise redirects to the CAS server (cas.somenergia.coop) without `allow_other_host: true`. Override `respond_to_on_destroy` in our sessions concern to pass the flag, plus a request spec covering the flow.


